### PR TITLE
fix: update portfolio filter buttons selector

### DIFF
--- a/assets/js/pages/portfolio.js
+++ b/assets/js/pages/portfolio.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     const projectListContainer = document.getElementById('project-list');
-    const filterButtons = document.querySelectorAll('.portfolio-gallery .btn[data-filter]');
+    // Seleccionar botones de filtrado dentro del contenedor con id "filter-buttons"
+    const filterButtons = document.querySelectorAll('#filter-buttons .btn[data-filter]');
 
     // Función para renderizar los proyectos en el HTML
     function renderProjects(projects) {


### PR DESCRIPTION
## Summary
- fix portfolio filter buttons query to target `#filter-buttons .btn[data-filter]`
- ensure active class toggles and projects filter accordingly

## Testing
- `node --check assets/js/pages/portfolio.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18c46e80083318957d46643276dd5