### PR TITLE
Ensure HTML lang attribute changes with language switch

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         element.textContent = translations[key];
                     }
                 });
+                document.documentElement.lang = lang;
                 localStorage.setItem('lang', lang);
             })
             .catch(error => console.error('Error loading language file:', error));


### PR DESCRIPTION
## Summary
- Update setLanguage to set the document's `<html lang>` attribute after translations are applied

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c18fc3530083319c69800b7da448ee