### PR TITLE
fix: correct CDN links in project page

### DIFF
--- a/portfolio/proyectos/proyecto-1.html
+++ b/portfolio/proyectos/proyecto-1.html
@@ -21,8 +21,8 @@
     <meta name="twitter:description" content="">
     <meta name="twitter:image" content="">
 
-    <link href="../../https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -110,7 +110,7 @@
         </div>
     </footer>
 
-    <script src="../../https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove incorrect `../../` prefixes from Bootstrap and Bootstrap Icons CDN links
- update Bootstrap script tag to load from CDN directly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mespdesingweb/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c197c4df548331916f56a9838e627e