### PR TITLE
Fix asset paths in legal pages

### DIFF
--- a/legal/cookies.html
+++ b/legal/cookies.html
@@ -19,8 +19,8 @@
     <meta name="twitter:description" content="">
     <meta name="twitter:image" content="">
 
-    <link href="../https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -31,8 +31,8 @@
     <link href="../assets/css/pages/legales.css" rel="stylesheet">
 
     <script src="../assets/js/seo.js" defer></script>
-    <script src="assets/js/i18n.js"></script>
-<script src="assets/js/theme.js"></script>
+    <script src="../assets/js/i18n.js"></script>
+    <script src="../assets/js/theme.js"></script>
 </head>
 <body data-page-id="cookies">
 
@@ -126,7 +126,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     
-    <script src="assets/js/main.js"></script>
-    <script src="assets/js/seo.js"></script>
+    <script src="../assets/js/main.js"></script>
 </body>
 </html>

--- a/legal/politica-privacidad.html
+++ b/legal/politica-privacidad.html
@@ -19,8 +19,8 @@
     <meta name="twitter:description" content="">
     <meta name="twitter:image" content="">
 
-    <link href="../https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -31,8 +31,8 @@
     <link href="../assets/css/pages/legales.css" rel="stylesheet">
 
     <script src="../assets/js/seo.js" defer></script>
-    <script src="assets/js/i18n.js"></script>
-<script src="assets/js/theme.js"></script>
+    <script src="../assets/js/i18n.js"></script>
+    <script src="../assets/js/theme.js"></script>
 </head>
 <body data-page-id="politica-privacidad">
 
@@ -156,8 +156,7 @@
     </footer>
 
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    
-    <script src="assets/js/main.js"></script>
-    <script src="assets/js/seo.js"></script>
+
+    <script src="../assets/js/main.js"></script>
 </body>
 </html>

--- a/legal/terminos-condiciones.html
+++ b/legal/terminos-condiciones.html
@@ -20,8 +20,8 @@
     <meta name="twitter:description" content="">
     <meta name="twitter:image" content="">
 
-    <link href="../https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -150,9 +150,8 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    
-    <script src="assets/js/main.js"></script>
-    <script src="assets/js/seo.js"></script>
+
+    <script src="../assets/js/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Correct malformed CDN links in legal HTML pages
- Reference local assets via `../assets/...`
- Remove duplicate `seo.js` script includes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81b96547483319f98ae919bde87f4